### PR TITLE
Added lftp to Dockerfile so the ftp backend is supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN set -x \
  && apk add --no-cache \
         ca-certificates \
         duplicity \
+	lftp \
         openssh \
         openssl \
         py-crypto \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN set -x \
  && apk add --no-cache \
         ca-certificates \
         duplicity \
-	lftp \
+        lftp \
         openssh \
         openssl \
         py-crypto \


### PR DESCRIPTION
Hi

I tried to create a backup using your image but I get the error message:

sh: lftp: not found
LFTP not found:  Please install LFTP.

The solution is to install the lftp package.

Cheers