### PR TITLE
Add automation to support building and pushing image to Docker Hub automatically

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,41 @@
+name: Build and publish
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.repository_owner }}/duplicity
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: latest/
+          file: ./latest/Dockerfile
+          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           context: latest/
           file: ./latest/Dockerfile
+          # Pushing only when we are running the workflow from a tag
+          # See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           push: ${{ startsWith(github.ref, 'refs/tags') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   build-docker:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub


### PR DESCRIPTION
This PR provides the ability to build and push the `latest` docker image when some conditions are met.

The pipeline executes on the following triggers:
- a PR is created against the repo (by default, PRs from forks are not executed for security reasons)
- Whenever the master branch is updated
- On tag creation in the format x.y.z (semver)

The docker image is built in all of these scenarios, but **only** when a tag occurs in the format described above is the image pushed to Docker Hub.

To work as expected, the secrets from DockerHub must be set on the repository. This guide supports the creation of the secrets: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions?tool=webui#creating-secrets-for-a-repository

The names must be exactly as follows:
- DOCKERHUB_USERNAME: will be the username of the owner of the docker hub account where the images are pushed
- DOCKERHUB_TOKEN: will be the token created to push the images. A new token can be created using this link (when logged in to Docker hub) https://hub.docker.com/settings/security?generateToken=true

The permissions required for DOCKERHUB_TOKEN is `Read & Write`